### PR TITLE
overwrite ENTRYPOINT and CMD

### DIFF
--- a/internal/cloud/cloud.go
+++ b/internal/cloud/cloud.go
@@ -219,6 +219,8 @@ func (cloud *Cloud) CreateContainer(
 		AttachStderr: true,
 		AttachStdin:  true,
 		Tty:          true,
+		Cmd:          []string{"sh"},
+		Entrypoint:   []string{""},
 	}
 
 	hostConfig := &container.HostConfig{


### PR DESCRIPTION
There are images that have a specific entrypoint which makes it
impossible to use this image for CI.

On the other hand, null-ing the entrypoint can cause an error related to
the fact that these images can have empty CMD field.

Therefore, we nullify ENTRYPOINT and set the simplest CMD as possible.