### PR TITLE
Windows: validate ssh-agent version

### DIFF
--- a/internal/sidecar/ssh-agent.go
+++ b/internal/sidecar/ssh-agent.go
@@ -70,10 +70,7 @@ func startSshAgent(
 		}
 
 		chError <- karma.Describe("cmd", cmd).Format(
-			"The ssh-agent process has chStarted and did not output the path to socket.\n"+
-				"You are probably using OpenSSH's ssh-agent which is not supported.\n"+
-				"Consider installing Git-BASH and adding Git-BASH's bin as a part of the system $PATH.\n"+
-				"Read more: https://snake-ci.com/docs/throubleshoot/windows-ssh-agent/",
+			"the ssh-agent process has started and did not output the path to socket",
 			"unable to start ssh-agent",
 		)
 	}()


### PR DESCRIPTION
Using the `ssh-agent` feature to run the specified command.

`ssh-agent cmd "/c exit 100"`:
* will return exit code 100 for valid `ssh-agent` and
* will return 0 for OpenSSH version of agent.

Exit code instead of echoing some string was chosen because `ssh-agent cmd '/c echo xxx'` will return `xxx"` (with hanging double quote) for some obscure reason.

Several other options to validate version were evaluated, but discarded:

* Using Windows feature to get executable version:

  ```
  PS > (Get-Item "C:\Windows\System32\OpenSSH\ssh-agent.exe").VersionInfo

  ProductVersion   FileVersion      FileName
  --------------   -----------      --------
  OpenSSH_7.7p1... 7.7.2.1          C:\Windows\System32\OpenSSH\ssh-agent.exe
  ```

  **—** PowerShell only (tried to find `cmd.exe` version of this, but the proposed solution did not work).

  **—** Unfortunately, it will not return anything for Git BASH's version of `ssh-agent`.

  **—** Requires `%PATH%` lookup first to find a path to the binary.

* Checking path to `ssh-agent`:

  **—** Obviously a very fragile solution.

* Running `ssh-agent -h` or similar:

  **—** The `-h` flag may get implemented in future versions.

  **—** Solution seems to be dirty and generally requires to match usage output, which may differ from version to version and may be localized.