### PR TITLE
PORT: overwrite ENTRYPOINT and CMD

### DIFF
--- a/internal/executor/docker/docker.go
+++ b/internal/executor/docker/docker.go
@@ -191,6 +191,8 @@ func (docker *Docker) Create(
 		AttachStderr: true,
 		AttachStdin:  true,
 		Tty:          true,
+		Cmd:          []string{"sh"},
+		Entrypoint:   []string{""},
 	}
 
 	hostConfig := &docker_container.HostConfig{


### PR DESCRIPTION
There are images that have a specific entrypoint which makes it
impossible to use this image for CI.

On the other hand, null-ing the entrypoint can cause an error related to
the fact that these images can have empty CMD field.

Therefore, we nullify ENTRYPOINT and set the simplest CMD as possible.